### PR TITLE
CI: Harden GHA configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: Test IPython CDI profile
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Apply recommended hardening steps including:

- pinning to a SHA any actions used
- not persisting the read token on checkout
- setting the default permissions to read-only
