### PR TITLE
update Tiled http client to use acquisition cluster

### DIFF
--- a/startup/00-base.py
+++ b/startup/00-base.py
@@ -23,11 +23,13 @@ tiled_writing_client = from_uri(
     "https://tiled.nsls2.bnl.gov/api/v1/metadata/cdi/raw",
     api_key=os.environ["TILED_BLUESKY_WRITING_API_KEY_CDI"],
 )
+tiled_writing_client.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 c = tiled_reading_client = from_uri(
     "https://tiled.nsls2.bnl.gov/api/v1/metadata/cdi/raw",
     include_data_sources=True,
 )
+c.context.http_client.headers['tiled-qos'] = 'acquisition'
 
 tw = TiledWriter(client=tiled_writing_client)
 


### PR DESCRIPTION
Add item that directs use of Tiled acquisition cluster to be used while acquiring data. Tiled clients from Prefect workflows, Jupyter notebooks, and other sources will be isolated from the acquisition cluster, ensuring data acquisition is not negatively affected by non-acquisition Tiled requests.