### PR TITLE
WIP: add cam1

### DIFF
--- a/startup/30-area-detectors.py
+++ b/startup/30-area-detectors.py
@@ -1,8 +1,9 @@
 from cditools.eiger_async import EigerDetector
 from cditools.merlin_async import MerlinDetector
 from nslsii.ophyd_async.providers import NSLS2PathProvider
+
 from ophyd_async.core import init_devices
-from ophyd_async.epics import adcore
+from ophyd_async.epics import adcore, advimba
 
 print("LOADING 30")
 
@@ -17,3 +18,9 @@ with init_devices():
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="merlines-1",
     )
+
+    cam1 = advimba.VimbaDetector(
+        "XF:09IDA-BI{DM:1-Cam:1}",
+        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+        name="cam-1",
+        )

--- a/startup/30-area-detectors.py
+++ b/startup/30-area-detectors.py
@@ -23,53 +23,53 @@ with init_devices():
         "XF:09IDA-BI{DM:1-Cam:1}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-1",
-        )
+    )
     cam2 = advimba.VimbaDetector(
         "XF:09IDA-BI{WBStop-Cam:2}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-2",
-        )
+    )
     cam3 = advimba.VimbaDetector(
         "XF:09IDA-BI{VPM-Cam:3}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-3",
-        )
+    )
     cam4 = advimba.VimbaDetector(
         "XF:09IDA-BI{HPM-Cam:4}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-5",
-        )
+    )
     cam5 = advimba.VimbaDetector(
         "XF:09IDA-BI{DM:2-Cam:5}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-5",
-        )
+    )
     cam6 = advimba.VimbaDetector(
         "XF:09IDB-BI{DM:3-Cam:6}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-6",
-        )
+    )
     cam7 = advimba.VimbaDetector(
         "XF:09IDC-BI{FS:KBv-Cam:7}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-7",
-        )
+    )
 
     cam8 = advimba.VimbaDetector(
         "XF:09IDC-BI{FS:KBh-Cam:8}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-8",
-        )
+    )
     cam9 = advimba.VimbaDetector(
         "XF:09IDC-BI{BCU-Cam:9}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-9",
-        )
+    )
     cam10 = advimba.VimbaDetector(
         "XF:09IDC-BI{SMPL-Cam:10}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-10",
-        )
+    )
     # cam15 = advimba.VimbaDetector(
     #     "XF:09IDC-BI{Cam:15}",
     #     adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),

--- a/startup/30-area-detectors.py
+++ b/startup/30-area-detectors.py
@@ -24,3 +24,54 @@ with init_devices():
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-1",
         )
+    cam2 = advimba.VimbaDetector(
+        "XF:09IDA-BI{WBStop-Cam:2}",
+        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+        name="cam-2",
+        )
+    cam3 = advimba.VimbaDetector(
+        "XF:09IDA-BI{VPM-Cam:3}",
+        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+        name="cam-3",
+        )
+    cam4 = advimba.VimbaDetector(
+        "XF:09IDA-BI{HPM-Cam:4}",
+        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+        name="cam-5",
+        )
+    cam5 = advimba.VimbaDetector(
+        "XF:09IDA-BI{DM:2-Cam:5}",
+        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+        name="cam-5",
+        )
+    cam6 = advimba.VimbaDetector(
+        "XF:09IDB-BI{DM:3-Cam:6}",
+        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+        name="cam-6",
+        )
+    cam7 = advimba.VimbaDetector(
+        "XF:09IDC-BI{FS:KBv-Cam:7}",
+        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+        name="cam-7",
+        )
+
+    cam8 = advimba.VimbaDetector(
+        "XF:09IDC-BI{FS:KBh-Cam:8}",
+        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+        name="cam-8",
+        )
+    cam9 = advimba.VimbaDetector(
+        "XF:09IDC-BI{BCU-Cam:9}",
+        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+        name="cam-9",
+        )
+    cam10 = advimba.VimbaDetector(
+        "XF:09IDC-BI{SMPL-Cam:10}",
+        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+        name="cam-10",
+        )
+    cam15 = advimba.VimbaDetector(
+        "XF:09IDC-BI{Cam:15}",
+        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+        name="cam-15",
+        )

--- a/startup/30-area-detectors.py
+++ b/startup/30-area-detectors.py
@@ -70,8 +70,8 @@ with init_devices():
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-10",
         )
-    cam15 = advimba.VimbaDetector(
-        "XF:09IDC-BI{Cam:15}",
-        adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
-        name="cam-15",
-        )
+    # cam15 = advimba.VimbaDetector(
+    #     "XF:09IDC-BI{Cam:15}",
+    #     adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
+    #     name="cam-15",
+    #     )

--- a/startup/30-area-detectors.py
+++ b/startup/30-area-detectors.py
@@ -7,6 +7,7 @@ from nslsii.ophyd_async.providers import NSLS2PathProvider
 from ophyd_async.core import SignalR, init_devices
 from ophyd_async.epics import adcore, advimba
 from ophyd_async.epics.core import stop_busy_record
+from ophyd_async.epics.adcore import ADState
 
 import asyncio
 
@@ -15,21 +16,32 @@ print("LOADING 30")
 pp = NSLS2PathProvider(RE.md)  # noqa: F821
 
 
-# TODO - move to cditools / nslsii
 class VimbaAcquireLogic(advimba.ADAcquireLogic):
 
     async def ensure_ready(self):
+        detector_state = await self.driver.detector_state.get_value()
+        self._cached_acquire_state = detector_state == ADState.ACQUIRE
         self._cached_trigger_mode = await self.driver.trigger_mode.get_value()
+        self._cached_image_mode = await self.driver.image_mode.get_value()
+
         await stop_busy_record(self.driver.acquire)
 
     async def ensure_stopped(self):
-        if self._cached_trigger_mode is not None:
-            await self.driver.trigger_mode.set(self._cached_trigger_mode)
-        self._cached_trigger_mode = None
         await stop_busy_record(self.driver.acquire)
 
+        if self._cached_trigger_mode is not None:
+            await self.driver.trigger_mode.set(self._cached_trigger_mode)
+        if self._cached_image_mode is not None:
+            await self.driver.image_mode.set(self._cached_image_mode)
+        self._cached_trigger_mode = None
+        self._cached_image_mode = None
 
-# TODO - rename and move to cditools / nslsii / ophyd-async
+        if self._cached_acquire_state is not None:
+            await self.driver.acquire.set(self._cached_acquire_state)
+        self._cached_acquire_state = None
+
+
+# TODO - move to ophyd-async
 class TmpAdvimba(advimba.VimbaDetector):
 
     def __init__(

--- a/startup/30-area-detectors.py
+++ b/startup/30-area-detectors.py
@@ -37,7 +37,7 @@ with init_devices():
     cam4 = advimba.VimbaDetector(
         "XF:09IDA-BI{HPM-Cam:4}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
-        name="cam-5",
+        name="cam-4",
     )
     cam5 = advimba.VimbaDetector(
         "XF:09IDA-BI{DM:2-Cam:5}",

--- a/startup/30-area-detectors.py
+++ b/startup/30-area-detectors.py
@@ -1,13 +1,58 @@
+from typing import Sequence
+
 from cditools.eiger_async import EigerDetector
 from cditools.merlin_async import MerlinDetector
 from nslsii.ophyd_async.providers import NSLS2PathProvider
 
-from ophyd_async.core import init_devices
+from ophyd_async.core import SignalR, init_devices
 from ophyd_async.epics import adcore, advimba
+from ophyd_async.epics.core import stop_busy_record
+
+import asyncio
 
 print("LOADING 30")
 
 pp = NSLS2PathProvider(RE.md)  # noqa: F821
+
+
+# TODO - move to cditools / nslsii
+class VimbaAcquireLogic(advimba.ADAcquireLogic):
+
+    async def ensure_ready(self):
+        self._cached_trigger_mode = await self.driver.trigger_mode.get_value()
+        await stop_busy_record(self.driver.acquire)
+
+    async def ensure_stopped(self):
+        if self._cached_trigger_mode is not None:
+            await self.driver.trigger_mode.set(self._cached_trigger_mode)
+        self._cached_trigger_mode = None
+        await stop_busy_record(self.driver.acquire)
+
+
+# TODO - rename and move to cditools / nslsii / ophyd-async
+class TmpAdvimba(advimba.VimbaDetector):
+
+    def __init__(
+            self,
+            prefix: str,
+            *writer_factories: advimba.ADWriterFactory,
+            driver_suffix="cam1:",
+            override_deadtime: float | None = None,
+            plugins: dict[str, advimba.NDPluginBaseIO] | None = None,
+            config_sigs: Sequence[SignalR] = (),
+            name: str = "",
+        ):
+        driver = advimba.VimbaDriverIO(prefix + driver_suffix)
+        super().__init__(
+            driver,
+            prefix,
+            *writer_factories,
+            acquire_logic=VimbaAcquireLogic(driver),
+            trigger_logic=advimba.VimbaTriggerLogic(driver, override_deadtime),
+            plugins=plugins,
+            config_sigs=config_sigs,
+            name=name,
+        )
 
 with init_devices():
     eiger = EigerDetector(
@@ -19,58 +64,58 @@ with init_devices():
         name="merlines-1",
     )
 
-    cam1 = advimba.VimbaDetector(
+    cam1 = TmpAdvimba(
         "XF:09IDA-BI{DM:1-Cam:1}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-1",
     )
-    cam2 = advimba.VimbaDetector(
+    cam2 = TmpAdvimba(
         "XF:09IDA-BI{WBStop-Cam:2}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-2",
     )
-    cam3 = advimba.VimbaDetector(
+    cam3 = TmpAdvimba(
         "XF:09IDA-BI{VPM-Cam:3}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-3",
     )
-    cam4 = advimba.VimbaDetector(
+    cam4 = TmpAdvimba(
         "XF:09IDA-BI{HPM-Cam:4}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-4",
     )
-    cam5 = advimba.VimbaDetector(
+    cam5 = TmpAdvimba(
         "XF:09IDA-BI{DM:2-Cam:5}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-5",
     )
-    cam6 = advimba.VimbaDetector(
+    cam6 = TmpAdvimba(
         "XF:09IDB-BI{DM:3-Cam:6}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-6",
     )
-    cam7 = advimba.VimbaDetector(
+    cam7 = TmpAdvimba(
         "XF:09IDC-BI{FS:KBv-Cam:7}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-7",
     )
 
-    cam8 = advimba.VimbaDetector(
+    cam8 = TmpAdvimba(
         "XF:09IDC-BI{FS:KBh-Cam:8}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-8",
     )
-    cam9 = advimba.VimbaDetector(
+    cam9 = TmpAdvimba(
         "XF:09IDC-BI{BCU-Cam:9}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-9",
     )
-    cam10 = advimba.VimbaDetector(
+    cam10 = TmpAdvimba(
         "XF:09IDC-BI{SMPL-Cam:10}",
         adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
         name="cam-10",
     )
-    # cam15 = advimba.VimbaDetector(
+    # cam15 = TmpAdvimba(
     #     "XF:09IDC-BI{Cam:15}",
     #     adcore.ADWriterFactory.hdf(pp, writer_suffix="HDF1:"),
     #     name="cam-15",

--- a/startup/30-area-detectors.py
+++ b/startup/30-area-detectors.py
@@ -1,32 +1,36 @@
+from typing import Annotated as A
 from typing import Sequence
 
 from cditools.eiger_async import EigerDetector
 from cditools.merlin_async import MerlinDetector
 from nslsii.ophyd_async.providers import NSLS2PathProvider
-
-from ophyd_async.core import SignalR, init_devices
+from ophyd_async.core import SignalR, SignalRW, init_devices
 from ophyd_async.epics import adcore, advimba
-from ophyd_async.epics.core import stop_busy_record
-from ophyd_async.epics.adcore import ADState
-
-import asyncio
+from ophyd_async.epics.adcore import ADAcquireLogic, ADState, AreaDetector
+from ophyd_async.epics.core import EpicsOptions, PvSuffix, stop_busy_record
 
 print("LOADING 30")
 
 pp = NSLS2PathProvider(RE.md)  # noqa: F821
 
 
-class VimbaAcquireLogic(advimba.ADAcquireLogic):
+class CustomVimbaDriverIO(advimba.VimbaDriverIO):
+    """FIXME: turn off put_completion for `acquire` PV"""
 
+    acquire: A[SignalRW[bool], PvSuffix.rbv("Acquire"), EpicsOptions(wait=False)]
+
+
+class VimbaAcquireLogic(ADAcquireLogic):
     async def ensure_ready(self):
         detector_state = await self.driver.detector_state.get_value()
-        self._cached_acquire_state = detector_state == ADState.ACQUIRE
+        self._cached_acquire_state = detector_state != ADState.IDLE
         self._cached_trigger_mode = await self.driver.trigger_mode.get_value()
         self._cached_image_mode = await self.driver.image_mode.get_value()
 
         await stop_busy_record(self.driver.acquire)
 
     async def ensure_stopped(self):
+        print()
         await stop_busy_record(self.driver.acquire)
 
         if self._cached_trigger_mode is not None:
@@ -42,19 +46,18 @@ class VimbaAcquireLogic(advimba.ADAcquireLogic):
 
 
 # TODO - move to ophyd-async
-class TmpAdvimba(advimba.VimbaDetector):
-
+class TmpAdvimba(AreaDetector[CustomVimbaDriverIO]):
     def __init__(
-            self,
-            prefix: str,
-            *writer_factories: advimba.ADWriterFactory,
-            driver_suffix="cam1:",
-            override_deadtime: float | None = None,
-            plugins: dict[str, advimba.NDPluginBaseIO] | None = None,
-            config_sigs: Sequence[SignalR] = (),
-            name: str = "",
-        ):
-        driver = advimba.VimbaDriverIO(prefix + driver_suffix)
+        self,
+        prefix: str,
+        *writer_factories: advimba.ADWriterFactory,
+        driver_suffix="cam1:",
+        override_deadtime: float | None = None,
+        plugins: dict[str, advimba.NDPluginBaseIO] | None = None,
+        config_sigs: Sequence[SignalR] = (),
+        name: str = "",
+    ):
+        driver = CustomVimbaDriverIO(prefix + driver_suffix)
         super().__init__(
             driver,
             prefix,
@@ -65,6 +68,7 @@ class TmpAdvimba(advimba.VimbaDetector):
             config_sigs=config_sigs,
             name=name,
         )
+
 
 with init_devices():
     eiger = EigerDetector(

--- a/startup/31-electrometers.py
+++ b/startup/31-electrometers.py
@@ -1,5 +1,4 @@
-import time
-from ophyd import Component as Cpt, EpicsSignal, EpicsSignalRO, Signal
+from ophyd import Component as Cpt, EpicsSignalRO
 from ophyd.device import Device
 
 print("LOADING 31")


### PR DESCRIPTION
I tested that cam1 saves data that can be read back through tiled, only verified that the rest connect.

cam15 needs investigation.

This is not ready to merge yet as we need to adjust these classes so that the exposure / period / mode / "is acquired" is restored to what it was before taking data.  We fixed this with the Eiger, but need to port this forward other detectors using ophyd-async.

We also need to port the ophyd(-sync) setup of the stats plugins these as well.